### PR TITLE
Issue #15. Only return sites in Oklahoma with bbox

### DIFF
--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -62,6 +62,8 @@ export class MainComponent implements OnInit {
 
         var geocoder = new MapboxGeocoder({
           accessToken: this._mapService.mapToken,
+          country: 'us',
+          bbox: [-103.000, 33.370, -94.260, 37.000]
         });
 
         this.map.addControl(geocoder, 'top-right');


### PR DESCRIPTION
Added a bbox to act as geofence to only return sites in Oklahoma. This allows user to search with just their street address, however there is no control for similar addresses in different cities.